### PR TITLE
Use new google place_id

### DIFF
--- a/lib/google_places/prediction.rb
+++ b/lib/google_places/prediction.rb
@@ -5,14 +5,12 @@ module GooglePlaces
 
     attr_accessor(
       :description,
-      :id,
-      :reference,
+      :place_id,
     )
 
     def initialize(json_result_object)
       @description = json_result_object['description']
-      @id = json_result_object['id']
-      @reference = json_result_object['reference']
+      @place_id = json_result_object['place_id']
     end
 
     # Query for Predictions (optionally at the provided location)


### PR DESCRIPTION
@chaslemley this fixed our issues with deprecation of `id` and `references`

https://developers.google.com/places/documentation/details

This will have to be merged at same time as this one:
https://github.com/hoteltonight/hotelstonight/pull/2516
